### PR TITLE
Some copy suggestions for clearer communication

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
         <div class="col-xs-12 col-sm-12 col-md-7 col-lg-6">
           <h2 class="u-showcase__text">LocalFreeWeb is a
             <a href="http://codeforsanfrancisco.org">Code for San
-            Francisco</a> initiative that brings internet enabled
+            Francisco</a> initiative that promotes internet enabled
             computers available to EVERYONE.
         </div>
 
@@ -53,7 +53,7 @@
       <section class="container-fluid u-section u-section--light space__bt--30">
         <heading>
           <h2 class="ct">How it works</h2>
-          <h3 class="ct space__bt--50">Get access to free internet enabled
+          <h3 class="ct space__bt--50">Get access to a free internet enabled
             computer in 3 easy steps.</h3>
         </heading>
 
@@ -81,7 +81,7 @@
           <section class="a-contextBox--20 a-contentBox--rnd a-contentBox--white">
             <i class="a-disc"><strong>3</strong></i>
             <h3>
-              Get free access to internet enabled devices.
+              Get free access to internet enabled computers.
             </h3>
           </section>
           <div
@@ -101,8 +101,7 @@
 
       <div class="space__bt--30 col-xs-12 col-sm-12 col-md-12 col-lg-12">
         <h2 class="ct">Add a new location</h2>
-        <h3 class="ct">Enter the information for the location where you will
-          provide "free internet"</h3>
+        <h3 class="ct">Enter information for another location that provides free internet</h3>
       </div>
 
       <div class="row-fluid cf" id="addLocation">
@@ -114,7 +113,7 @@
           <form class="form-horizontal" role="form" method="POST"
             action="https://docs.google.com/forms/d/1wtzh1gm04XhglsC8am8e5GoTlbwvF20kOAB75cex8bY/formResponse">
             <div class="form-group">
-              <label for="userName" class="col-sm-3 control-label">Business Name</label>
+              <label for="userName" class="col-sm-3 control-label">Location Name</label>
               <div class="col-sm-9">
                 <input type="text" class="form-control" id="userName"
                   name="entry.2026024928"
@@ -154,7 +153,7 @@
               <div class="col-sm-9">
                 <input type="text" class="form-control" id="userAddrZipcode"
                   name="entry.1541354702"
-                  placeholder="ZipCode">
+                  placeholder="Zipcode">
               </div>
             </div>
             <div class="form-group">
@@ -206,12 +205,12 @@
         <section class="col-xs-12 col-sm-12 col-md-5 col-md-offset-1
           col-lg-offset-1 col-lg-5">
           <h4>About</h4>
-          <p class="space__bt--40">Localfreeweb is brought to you by
+          <p class="space__bt--40">LocalFreeWeb is brought to you by
             <a href="http://codeforsanfrancisco.org">Code
               for San Francisco</a>, a Code for America brigade.
           </p>
           <h4>Get involved</h4>
-          <p class="space__bt--40">Interested in setting up Localfreeweb for
+          <p class="space__bt--40">Interested in setting up LocalFreeWeb for
             your city? Fork the repo:
             <a
               href="https://github.com/sfbrigade/localfreeweb-sms-api">
@@ -232,7 +231,7 @@
                   href="https://github.com/sfbrigade/localfreeweb-sms-api">
                   Github repository</a></li>
                 <li><a target="_blank"
-                  href="https://github.com/sfbrigade/localfreeweb.org">
+                  href="https://github.com/sfbrigade/localfreeweb.org/tree/gh-pages">
                   Website Github repository</a></li>
                 <li><a href="http://codeforsanfrancisco.org">
                   Code for San Francisco</a></li>


### PR DESCRIPTION
Just some suggestions! I hope this is helpful; feel free to accept whatever seems useful.

Instead of LocalFreeWeb "bringing" internet-enabled computers, it may be more precise to say LocalFreeWeb "promotes" them - I see this as the libraries and other locations bringing access to people, and LocalFreeWeb helping by sharing information.

"Get access to free internet enabled computer" sounds better to me as "Get access to a free internet enabled computer".

"Internet enabled devices" implies phones/tablets to me, and the site seems to focus on computers, so I changed that to "internet enabled computers" (which is also better for consistency).

For "Enter the information for the location where you will provide "free internet"", I imagine that most of the people adding locations will be adding the names of organizations they know about instead of setting up new access locations (since setting up new access locations is very hard), so I updated this to say "Enter information for another location that provides free internet" (and omitted the extra quotation marks).

I changed "Business Name" to the more neutral "Location Name" since many additional locations are likely to be nonprofit organizations or other non-business institutions.

I made capitalization more consistent in a few places.

The current website repository link goes to an empty branch, so I changed that link to go to the branch where the website code seems to live.
