### PR TITLE
Modified medium and large screen column values in line 39

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       </div>
 
       <div class="container-fluid u-showcase cf">
-        <div class="col-xs-0 col-sm-0 col-md-4 col-lg-5
+        <div class="col-xs-0 col-sm-0 col-md-5 col-lg-6
                     hidden-xs hidden-sm">
            <img src="/image/banner.png" />
         </div>


### PR DESCRIPTION
When the window is certain sizes in Google Chrome, the text "LocalFreeWeb is a Code...available to EVERYONE" overlaps with the image of the computer with "FREE" printed on it. I'm assuming this change would fix this issue, as it may have been because the column values previously did not add up to 12, but my editor doesn't allow me to preview the image so I can't be sure.
